### PR TITLE
Added ability to create a Triangulation with only points and triangles as input

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## 1.5.0
 
-- Added the ability to generate unconstrained triangulations with the constructor Triangulation(points, triangles). See [#192](https://github.com/JuliaGeometry/DelaunayTriangulation.jl/pull/192)
+- Introduced the ability to reconstruct unconstrained triangulations from an existing set of points and triangles using `Triangulation(points, triangles)`. See [#192](https://github.com/JuliaGeometry/DelaunayTriangulation.jl/pull/192)
 
 ## 1.4.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## 1.4.0
 
 - Updated to AdaptivePredicates.jl v1.2, now allowing caches to be passed to the predicates involving `incircle` and `orient3`. These are only useful when using the `AdaptiveKernel()` kernel. Outside of triangulating, these caches are not passed by default, but can be provided. The functions `get_incircle_cache` and `get_orient3_cache` can be used for this purpose on a triangulation (without a triangulation, refer to AdaptivePredicate.jl's `incircleadapt_cache` and `orient3adapt_cache`). See [#185](https://github.com/JuliaGeometry/DelaunayTriangulation.jl/pull/185).
+- Added the ability to generate unconstrained triangulations with the constructor Triangulation(points, triangles). See [#192](https://github.com/JuliaGeometry/DelaunayTriangulation.jl/pull/192)
 
 ## 1.3.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,12 @@
 # Changelog
 
+## 1.5.0
+
+- Added the ability to generate unconstrained triangulations with the constructor Triangulation(points, triangles). See [#192](https://github.com/JuliaGeometry/DelaunayTriangulation.jl/pull/192)
+
 ## 1.4.0
 
 - Updated to AdaptivePredicates.jl v1.2, now allowing caches to be passed to the predicates involving `incircle` and `orient3`. These are only useful when using the `AdaptiveKernel()` kernel. Outside of triangulating, these caches are not passed by default, but can be provided. The functions `get_incircle_cache` and `get_orient3_cache` can be used for this purpose on a triangulation (without a triangulation, refer to AdaptivePredicate.jl's `incircleadapt_cache` and `orient3adapt_cache`). See [#185](https://github.com/JuliaGeometry/DelaunayTriangulation.jl/pull/185).
-- Added the ability to generate unconstrained triangulations with the constructor Triangulation(points, triangles). See [#192](https://github.com/JuliaGeometry/DelaunayTriangulation.jl/pull/192)
 
 ## 1.3.1
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DelaunayTriangulation"
 uuid = "927a84f5-c5f4-47a5-9785-b46e178433df"
 authors = ["Daniel VandenHeuvel <danj.vandenheuvel@gmail.com>"]
-version = "1.4.2"
+version = "1.5.0"
 
 [deps]
 AdaptivePredicates = "35492f91-a3bd-45ad-95db-fcad7dcfedb7"

--- a/src/data_structures/triangulation/triangulation.jl
+++ b/src/data_structures/triangulation/triangulation.jl
@@ -523,10 +523,11 @@ end
 """
     Triangulation(points, triangles; kwargs...) -> Triangulation
 
-Returns the `Triangulation` corresponding to the triangulation of `points` with `triangles`.
+Returns the unconstrained `Triangulation` corresponding to the triangulation of `points` with `triangles`.
+WARNING: Since it uses 'convex_hull' on the points to find the boundary it may not work if there are some points in points that are not vertices in triangles.
 
 # Arguments 
-- `points`: The points that the triangulation is of. 
+- `points`: The points that the triangulation is of, there should not be any points not referenced in `triangles`.
 - `triangles`: The triangles of the triangulation. These should be given in counter-clockwise order, with vertices corresponding to `points`. These should not include any ghost triangles.
 
 # Keyword Arguments 
@@ -553,7 +554,8 @@ Returns the `Triangulation` corresponding to the triangulation of `points` with 
     delete_ghosts=false,
     predicates::AbstractPredicateKernel=AdaptiveKernel(),
 ) where {P,T,I,E,V,Es,Ts}
-    return Triangulation(points, triangles, [nothing]; IntegerType, EdgeType, TriangleType, EdgesType, TrianglesType, weights, delete_ghosts, predicates)
+    _bn = get_vertices(convex_hull(points; predicates, IntegerType))
+    return Triangulation(points, triangles, boundary_nodes=_bn; IntegerType, EdgeType, TriangleType, EdgesType, TrianglesType, weights, delete_ghosts, predicates)
 end
 
 """

--- a/src/data_structures/triangulation/triangulation.jl
+++ b/src/data_structures/triangulation/triangulation.jl
@@ -521,6 +521,42 @@ Returns the `Triangulation` corresponding to the triangulation of `points` with 
 end
 
 """
+    Triangulation(points, triangles; kwargs...) -> Triangulation
+
+Returns the `Triangulation` corresponding to the triangulation of `points` with `triangles`.
+
+# Arguments 
+- `points`: The points that the triangulation is of. 
+- `triangles`: The triangles of the triangulation. These should be given in counter-clockwise order, with vertices corresponding to `points`. These should not include any ghost triangles.
+
+# Keyword Arguments 
+- `predicates::AbstractPredicateKernel=AdaptiveKernel()`: Method to use for computing predicates. Can be one of [`FastKernel`](@ref), [`ExactKernel`](@ref), and [`AdaptiveKernel`](@ref). See the documentation for a further discussion of these methods.
+- `IntegerType=Int`: The integer type to use for the triangulation. This is used for representing vertices.
+- `EdgeType=isnothing(segments) ? NTuple{2,IntegerType} : (edge_type ∘ typeof)(segments)`: The edge type to use for the triangulation. 
+- `TriangleType=NTuple{3,IntegerType}`: The triangle type to use for the triangulation.
+- `EdgesType=isnothing(segments) ? Set{EdgeType} : typeof(segments)`: The type to use for storing the edges of the triangulation.
+- `TrianglesType=Set{TriangleType}`: The type to use for storing the triangles of the triangulation.
+- `weights=ZeroWeight()`: The weights associated with the triangulation. 
+- `delete_ghosts=false`: Whether to delete the ghost triangles after the triangulation is computed. This is done using [`delete_ghost_triangles!`](@ref).
+
+# Output 
+- `tri`: The [`Triangulation`](@ref).
+"""
+@inline function Triangulation(
+    points::P, triangles::T;
+    IntegerType::Type{I}=Int,
+    EdgeType::Type{E}=NTuple{2,IntegerType},
+    TriangleType::Type{V}=NTuple{3,IntegerType},
+    EdgesType::Type{Es}=Set{EdgeType},
+    TrianglesType::Type{Ts}=Set{TriangleType},
+    weights=ZeroWeight(),
+    delete_ghosts=false,
+    predicates::AbstractPredicateKernel=AdaptiveKernel(),
+) where {P,T,I,E,V,Es,Ts}
+    tri = Triangulation(points; boundary_nodes=[nothing], weights, IntegerType, EdgeType, TriangleType, EdgesType, TrianglesType)
+    return build_triangulation_from_data!(tri, triangles, _bn, delete_ghosts, predicates)
+
+"""
     build_triangulation_from_data!(tri::Triangulation, triangles, boundary_nodes, delete_ghosts, predicates::AbstractPredicateKernel=AdaptiveKernel())
 
 Given an empty `triangulation`, `tri`, adds all the `triangles` and `boundary_nodes` into it. Use 

--- a/src/data_structures/triangulation/triangulation.jl
+++ b/src/data_structures/triangulation/triangulation.jl
@@ -553,7 +553,8 @@ Returns the `Triangulation` corresponding to the triangulation of `points` with 
     delete_ghosts=false,
     predicates::AbstractPredicateKernel=AdaptiveKernel(),
 ) where {P,T,I,E,V,Es,Ts}
-    tri = Triangulation(points; boundary_nodes=[nothing], weights, IntegerType, EdgeType, TriangleType, EdgesType, TrianglesType)
+    _bn = [nothing]
+    tri = Triangulation(points; boundary_nodes=_bn, weights, IntegerType, EdgeType, TriangleType, EdgesType, TrianglesType)
     return build_triangulation_from_data!(tri, triangles, _bn, delete_ghosts, predicates)
 end
 

--- a/src/data_structures/triangulation/triangulation.jl
+++ b/src/data_structures/triangulation/triangulation.jl
@@ -553,9 +553,7 @@ Returns the `Triangulation` corresponding to the triangulation of `points` with 
     delete_ghosts=false,
     predicates::AbstractPredicateKernel=AdaptiveKernel(),
 ) where {P,T,I,E,V,Es,Ts}
-    _bn = [nothing]
-    tri = Triangulation(points; boundary_nodes=_bn, weights, IntegerType, EdgeType, TriangleType, EdgesType, TrianglesType)
-    return build_triangulation_from_data!(tri, triangles, _bn, delete_ghosts, predicates)
+    return Triangulation(points, triangles, [nothing]; IntegerType, EdgeType, TriangleType, EdgesType, TrianglesType, weights, delete_ghosts, predicates)
 end
 
 """

--- a/src/data_structures/triangulation/triangulation.jl
+++ b/src/data_structures/triangulation/triangulation.jl
@@ -555,6 +555,7 @@ Returns the `Triangulation` corresponding to the triangulation of `points` with 
 ) where {P,T,I,E,V,Es,Ts}
     tri = Triangulation(points; boundary_nodes=[nothing], weights, IntegerType, EdgeType, TriangleType, EdgesType, TrianglesType)
     return build_triangulation_from_data!(tri, triangles, _bn, delete_ghosts, predicates)
+end
 
 """
     build_triangulation_from_data!(tri::Triangulation, triangles, boundary_nodes, delete_ghosts, predicates::AbstractPredicateKernel=AdaptiveKernel())

--- a/src/data_structures/triangulation/triangulation.jl
+++ b/src/data_structures/triangulation/triangulation.jl
@@ -555,7 +555,7 @@ WARNING: Since it uses 'convex_hull' on the points to find the boundary it may n
     predicates::AbstractPredicateKernel=AdaptiveKernel(),
 ) where {P,T,I,E,V,Es,Ts}
     _bn = get_vertices(convex_hull(points; predicates, IntegerType))
-    return Triangulation(points, triangles, boundary_nodes=_bn; IntegerType, EdgeType, TriangleType, EdgesType, TrianglesType, weights, delete_ghosts, predicates)
+    return Triangulation(points, triangles, _bn; IntegerType, EdgeType, TriangleType, EdgesType, TrianglesType, weights, delete_ghosts, predicates)
 end
 
 """

--- a/test/data_structures/triangulation.jl
+++ b/test/data_structures/triangulation.jl
@@ -1475,3 +1475,13 @@ end
         end
     end
 end
+
+@testset "Constructor with only points and triangles" begin
+    points = [(0.0, 0.0), (0.87, 0.0), (1.0006, 0.7766), (0.0, 1.0), (0.5, 0.5)]
+    tri1 = triangulate(points)
+    triangles = tri1.triangles
+    tri2 = DT.Triangulation(points, triangles)
+    @test validate_triangulation(tri2)
+    @test tri1 == tri2
+    @test !DT.has_boundary_nodes(tri2)
+end

--- a/test/triangulation/triangulate.jl
+++ b/test/triangulation/triangulate.jl
@@ -37,3 +37,12 @@ end
         end
     end
 end
+
+@testset "Constructor with only points and triangles" begin
+    points = [(0.0, 0.0), (0.87, 0.0), (1.0006, 0.7766), (0.0, 1.0), (0.5, 0.5)]
+    tri1 = triangulate(points)
+    triangles = tri.triangles
+    tri2 = DT.Triangulation(points, triangles)
+    @test validate_triangulation(tri2)
+    @test tri1 == tri2
+end

--- a/test/triangulation/triangulate.jl
+++ b/test/triangulation/triangulate.jl
@@ -37,12 +37,3 @@ end
         end
     end
 end
-
-@testset "Constructor with only points and triangles" begin
-    points = [(0.0, 0.0), (0.87, 0.0), (1.0006, 0.7766), (0.0, 1.0), (0.5, 0.5)]
-    tri1 = triangulate(points)
-    triangles = tri1.triangles
-    tri2 = DT.Triangulation(points, triangles)
-    @test validate_triangulation(tri2)
-    @test tri1 == tri2
-end

--- a/test/triangulation/triangulate.jl
+++ b/test/triangulation/triangulate.jl
@@ -41,7 +41,7 @@ end
 @testset "Constructor with only points and triangles" begin
     points = [(0.0, 0.0), (0.87, 0.0), (1.0006, 0.7766), (0.0, 1.0), (0.5, 0.5)]
     tri1 = triangulate(points)
-    triangles = tri.triangles
+    triangles = tri1.triangles
     tri2 = DT.Triangulation(points, triangles)
     @test validate_triangulation(tri2)
     @test tri1 == tri2


### PR DESCRIPTION
In case someone already has an unconstrained triangulation in the form of points and triangles, but no boundary, I added a constructor for exactly that. It's basically calling the previous method with boundary_nodes = [nothing].